### PR TITLE
Set execution mode to thread in order to fix gRPC error

### DIFF
--- a/nanobenchmarks/gen_flink.py
+++ b/nanobenchmarks/gen_flink.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+from pyflink.common import Configuration
 from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
 
@@ -31,11 +32,14 @@ def run_experiment(env, blowup: int = -1, parallelism: int = -1, size: int = -1)
 
 
 def main():
-    env = StreamExecutionEnvironment.get_execution_environment()
-    env.set_parallelism(50)
+    config = Configuration()
 
+    # Specify `THREAD` mode
+    config.set_string("python.execution-mode", "thread")
+
+    env = StreamExecutionEnvironment.get_execution_environment(config)
+    env.set_parallelism(15)
     run_experiment(env, size=10000)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR fixes #9 by setting PyFlink config's `python.execution-mode` to `THREAD`.  

By default, PyFlink adopts the `PROCESS` execution mode, where "Python user-defined functions will be executed in separate Python process." (See [PyFlink documentation](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/dev/python/python_execution_mode/#configuring-python-execution-mode)).

Setting execution mode to THREAD runs the code within the same JVM, as threads, rather than in separate python processes. This helps avoid the network communication overhead associated with the `PROCESS` mode, where gRPC is utilized.

Execution behaviors of `PROCESS` (fig 1) and `THREAD` (fig 2) modes:
![image](https://github.com/franklsf95/ray-data-eval/assets/78146401/273e20d0-7c3a-446a-bb7f-31b33523caeb)
![image](https://github.com/franklsf95/ray-data-eval/assets/78146401/944eeba3-c912-49ef-b784-40a7e70f8b40)

