### PR TITLE
Add uniform tasks spark ver

### DIFF
--- a/nanobenchmarks/uniform_spark.py
+++ b/nanobenchmarks/uniform_spark.py
@@ -1,0 +1,97 @@
+"""
+Testing Spark structured streaming execution
+"""
+
+import os
+import time
+
+import numpy as np
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, IntegerType, BinaryType
+
+
+DATA_SIZE_BYTES = 1000 * 1000 * 100  # 100 MB
+TIME_BASIS = 0.1  # How many seconds should time_factor=1 take
+
+
+def memory_blowup(row, time_factor=1):
+    i = row["item"]
+    data = bytearray(np.full(DATA_SIZE_BYTES, 1, dtype=np.uint8))
+    time.sleep(TIME_BASIS * time_factor)
+    return {"data": data, "idx": i}
+
+
+def memory_shrink(row, time_factor=1):
+    data = row["data"]
+    np_data = np.frombuffer(data, dtype=np.uint8)
+    time.sleep(TIME_BASIS * time_factor)
+    return (int(np_data.sum()),)
+
+
+def run_experiment(
+    spark, parallelism=-1, num_parts=100, producer_time=1, consumer_time=1
+):
+    start = time.perf_counter()
+
+    items = [(item,) for item in range(num_parts)]
+    input_schema = ["item"]
+    df = spark.createDataFrame(data=items, schema=input_schema)
+    df = df.repartition(parallelism)
+
+    blowup_schema = StructType(
+        [
+            StructField("data", BinaryType(), True),
+            StructField("idx", IntegerType(), True),
+        ]
+    )
+    df = df.rdd.map(lambda row: memory_blowup(row, time_factor=producer_time)).toDF(
+        blowup_schema
+    )
+
+    result_schema = StructType([StructField("result", IntegerType(), True)])
+    df = df.rdd.map(lambda row: memory_shrink(row, time_factor=consumer_time)).toDF(
+        result_schema
+    )
+
+    ret = df.agg({"result": "sum"}).collect()[0][0]
+
+    run_time = time.perf_counter() - start
+    print(f"\n{ret:,}")
+    print(df.explain())
+    print(run_time)
+
+
+def main():
+    spark = (
+        SparkSession.builder.appName("Spark")
+        .config("spark.eventLog.enabled", "true")
+        .config("spark.eventLog.dir", os.getenv("SPARK_EVENTS_FILEURL"))
+        .config("spark.executor.memory", "20g")
+        .config("spark.driver.memory", "20g")
+        .config("spark.executor.instances", "100")
+        .getOrCreate()
+    )
+
+    config = {
+        "parallelism": 200,
+        "total_data_size_gb": 100,
+        "producer_time": 1,
+        "consumer_time": 9,
+    }
+    config["total_data_size"] = config["total_data_size_gb"] * 10**9
+    config["num_parts"] = config["total_data_size"] // DATA_SIZE_BYTES
+    config["producer_consumer_ratio"] = (
+        config["producer_time"] / config["consumer_time"]
+    )
+
+    run_experiment(
+        spark,
+        parallelism=config["parallelism"],
+        num_parts=config["num_parts"],
+        producer_time=config["producer_time"],
+        consumer_time=config["consumer_time"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Overview
- Spark structured streaming execution for uniform tasks experiment
- Ray Data ver: https://github.com/franklsf95/ray-data-eval/blob/main/nanobenchmarks/uniform.py

Configuration:
- Total data size 100GB
- Parallelism 200/100/20
- Experimentation results: https://docs.google.com/document/d/1_wH636kQczkxHdxuKLedihjxvhfRDJdffoWd7aVl4yU/edit

Adaptation Notes: 
- PySpark's DataFrame API does not directly provide a parameter equivalent to `num_gpus` as in the Ray library
- Spark Structured Streaming does not have a backpressure mechanism, since handling back pressure is needed only is push based mechanisms