### PR TITLE
Prevent auto chaining operations for spark uniform

### DIFF
--- a/ray_data_eval/nanobenchmarks/uniform_spark.py
+++ b/ray_data_eval/nanobenchmarks/uniform_spark.py
@@ -43,6 +43,8 @@ def run_experiment(spark, parallelism=-1, num_parts=100, producer_time=1, consum
     )
     df = df.rdd.map(lambda row: memory_blowup(row, time_factor=producer_time)).toDF(blowup_schema)
 
+    df = df.repartition(parallelism)
+
     result_schema = StructType([StructField("result", IntegerType(), True)])
     df = df.rdd.map(lambda row: memory_shrink(row, time_factor=consumer_time)).toDF(result_schema)
 

--- a/ray_data_eval/nanobenchmarks/uniform_spark.py
+++ b/ray_data_eval/nanobenchmarks/uniform_spark.py
@@ -16,16 +16,15 @@ TIME_BASIS = 0.1  # How many seconds should time_factor=1 take
 
 def memory_blowup(row, time_factor=1):
     i = row["item"]
-    data = bytearray(np.full(DATA_SIZE_BYTES, 1, dtype=np.uint8))
+    data = b"1" * DATA_SIZE_BYTES
     time.sleep(TIME_BASIS * time_factor)
     return {"data": data, "idx": i}
 
 
 def memory_shrink(row, time_factor=1):
     data = row["data"]
-    np_data = np.frombuffer(data, dtype=np.uint8)
     time.sleep(TIME_BASIS * time_factor)
-    return (int(np_data.sum()),)
+    return (int(len(data)),)
 
 
 def run_experiment(spark, parallelism=-1, num_parts=100, producer_time=1, consumer_time=1):

--- a/ray_data_eval/nanobenchmarks/uniform_spark.py
+++ b/ray_data_eval/nanobenchmarks/uniform_spark.py
@@ -5,7 +5,6 @@ Testing Spark structured streaming execution
 import os
 import time
 
-import numpy as np
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, IntegerType, BinaryType
 


### PR DESCRIPTION
- Updated uniform_spark.py to force two map transformations to not be merged
- Experiment results are recorded at https://docs.google.com/document/d/1_wH636kQczkxHdxuKLedihjxvhfRDJdffoWd7aVl4yU/edit