### PR TITLE
Add script to parse spark event log for timeline view

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 layout anaconda raydata
 export SPARK_EVENTS_PATH=/home/ubuntu/ray-data-eval/logs/spark-events
+export SPARK_TRACE_EVENT_PATH=/home/ubuntu/ray-data-eval/logs/spark-trace-events
 export SPARK_EVENTS_FILEURL=file://$SPARK_EVENTS_PATH
 export SPARK_HOME=/home/ubuntu/ray-data-eval/bin/spark
 export PYSPARK_PYTHON=/home/ubuntu/miniconda3/envs/raydata/bin/python

--- a/ray_data_eval/nanobenchmarks/spark/parse_spark_eventLog.py
+++ b/ray_data_eval/nanobenchmarks/spark/parse_spark_eventLog.py
@@ -1,0 +1,53 @@
+import os
+import json
+
+
+def spark_timeline():
+    # logs/spark-events/app-20240109133439-0022
+
+    log_directory = os.getenv("SPARK_EVENTS_PATH")
+    app_id = "app-20240115141650-0146"
+
+    job_info_dict = {}
+
+    file = os.path.join(log_directory, app_id)
+    with open(file, "r") as f:
+        for line in f:
+            event = json.loads(line)
+
+            if event["Event"] == "SparkListenerJobStart":
+                job_id = event["Job ID"]
+                job_info_dict[job_id] = {
+                    "start_time": (event["Submission Time"]),
+                    "tasks": [],
+                }
+
+            elif event["Event"] == "SparkListenerTaskEnd":
+                task_info = event["Task End Reason"]
+                start_time = event["Task Info"]["Launch Time"]
+                end_time = event["Task Info"]["Finish Time"]
+                task_id = event["Task Info"]["Task ID"]
+
+                job_info_dict[job_id]["tasks"].append(
+                    {
+                        "task_id": task_id,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "task_info": task_info,
+                    }
+                )
+
+    for job_id, job_info in job_info_dict.items():
+        print(f"Job ID: {job_id}, Start Time: {job_info['start_time']}")
+        for task_info in job_info["tasks"]:
+            print(
+                f"  Task ID: {task_info['task_id']}, Start Time: {task_info['start_time']}, End Time: {task_info['end_time']}, Task Info: {task_info['task_info']}"
+            )
+
+
+def main():
+    spark_timeline()
+
+
+if __name__ == "__main__":
+    main()

--- a/ray_data_eval/nanobenchmarks/spark/parse_spark_eventLog.py
+++ b/ray_data_eval/nanobenchmarks/spark/parse_spark_eventLog.py
@@ -2,51 +2,50 @@ import os
 import json
 
 
-def spark_timeline():
+def make_trace_event_spark():
     # logs/spark-events/app-20240109133439-0022
+    app_id = "app-20240119050536-0174"
 
     log_directory = os.getenv("SPARK_EVENTS_PATH")
-    app_id = "app-20240115141650-0146"
+    output_directory = os.getenv("SPARK_TRACE_EVENT_PATH")
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
 
-    job_info_dict = {}
+    events = []
 
     file = os.path.join(log_directory, app_id)
     with open(file, "r") as f:
         for line in f:
             event = json.loads(line)
 
-            if event["Event"] == "SparkListenerJobStart":
-                job_id = event["Job ID"]
-                job_info_dict[job_id] = {
-                    "start_time": (event["Submission Time"]),
-                    "tasks": [],
-                }
-
-            elif event["Event"] == "SparkListenerTaskEnd":
-                task_info = event["Task End Reason"]
+            if event["Event"] == "SparkListenerTaskEnd":
                 start_time = event["Task Info"]["Launch Time"]
                 end_time = event["Task Info"]["Finish Time"]
                 task_id = event["Task Info"]["Task ID"]
+                executor_id = event["Task Info"]["Executor ID"]
+                host = event["Task Info"]["Host"]
 
-                job_info_dict[job_id]["tasks"].append(
-                    {
-                        "task_id": task_id,
-                        "start_time": start_time,
-                        "end_time": end_time,
-                        "task_info": task_info,
-                    }
-                )
+                event = {
+                    "cat": f"task:{task_id}",
+                    "name": f"task:{task_id}",
+                    "pid": host,
+                    "tid": f"worker:{executor_id}",
+                    "ts": start_time,  # start time (ms)
+                    "dur": (end_time - start_time),  # duration (ms)
+                    "ph": "X",
+                    "args": {},
+                }
 
-    for job_id, job_info in job_info_dict.items():
-        print(f"Job ID: {job_id}, Start Time: {job_info['start_time']}")
-        for task_info in job_info["tasks"]:
-            print(
-                f"  Task ID: {task_info['task_id']}, Start Time: {task_info['start_time']}, End Time: {task_info['end_time']}, Task Info: {task_info['task_info']}"
-            )
+                events.append(event)
+
+    output_file = os.path.join(output_directory, f"timeline_{app_id}.json")
+    with open(output_file, "w") as output_f:
+        json.dump(events, output_f, indent=2)
+        print(f"Output saved to: {output_file}")
 
 
 def main():
-    spark_timeline()
+    make_trace_event_spark()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Parse a specific spark event log (stored locally in SPARK_EVENTS_PATH) for Jobs->Tasks {Start Time, End Time}
- Stage not included since this code version has 1 stage per job, and spark auto skips certain stages leads to non-sequential stage ID

- An example console output of parsed view
<img width="608" alt="Screen Shot 2024-01-15 at 6 59 29 AM" src="https://github.com/franklsf95/ray-data-eval/assets/77655652/8bc355ee-0f24-490a-9293-a9d4c790e0d8">
