### PR TITLE
Modify Ray+Transform pipeline

### DIFF
--- a/ray_data_eval/image_training/image_loader_microbenchmark.py
+++ b/ray_data_eval/image_training/image_loader_microbenchmark.py
@@ -61,9 +61,7 @@ def iterate(dataset, label, batch_size, output_file=None):
         f.write(f"{label},{tput}\n")
 
 
-def build_torch_dataset(
-    root_dir, batch_size, shuffle=False, num_workers=None, transform=None
-):
+def build_torch_dataset(root_dir, batch_size, shuffle=False, num_workers=None, transform=None):
     if num_workers is None:
         num_workers = os.cpu_count()
 
@@ -81,9 +79,7 @@ def build_torch_dataset(
 def parse_and_decode_tfrecord(example_serialized):
     feature_map = {
         "image/encoded": tf.io.FixedLenFeature([], dtype=tf.string, default_value=""),
-        "image/class/label": tf.io.FixedLenFeature(
-            [], dtype=tf.int64, default_value=-1
-        ),
+        "image/class/label": tf.io.FixedLenFeature([], dtype=tf.int64, default_value=-1),
     }
 
     features = tf.io.parse_single_example(example_serialized, feature_map)
@@ -161,9 +157,7 @@ def tf_crop_and_flip(image_buffer, num_channels=3):
 
 
 def build_tfrecords_tf_dataset(data_root, batch_size):
-    filenames = [
-        os.path.join(data_root, pathname) for pathname in os.listdir(data_root)
-    ]
+    filenames = [os.path.join(data_root, pathname) for pathname in os.listdir(data_root)]
     ds = tf.data.Dataset.from_tensor_slices(filenames)
     ds = ds.interleave(tf.data.TFRecordDataset).map(
         parse_and_decode_tfrecord, num_parallel_calls=tf.data.experimental.AUTOTUNE
@@ -313,9 +307,7 @@ class S3MosaicDataset(StreamingDataset):
         return self.transforms(image), label
 
 
-def build_mosaic_dataloader(
-    mosaic_data_root, batch_size, num_workers=None, tranform=None
-):
+def build_mosaic_dataloader(mosaic_data_root, batch_size, num_workers=None, tranform=None):
     # MosaicML StreamingDataset.
     use_s3 = mosaic_data_root.startswith("s3://")
 
@@ -349,9 +341,7 @@ def build_mosaic_dataloader(
     return mosaic_dl
 
 
-def build_hf_dataloader(
-    data_root, batch_size, from_images, num_workers=None, transform=None
-):
+def build_hf_dataloader(data_root, batch_size, from_images, num_workers=None, transform=None):
     if num_workers is None:
         num_workers = os.cpu_count()
 
@@ -359,9 +349,7 @@ def build_hf_dataloader(
 
     def transforms(examples):
         if from_images:
-            examples["image"] = [
-                transform(image.convert("RGB")) for image in examples["image"]
-            ]
+            examples["image"] = [transform(image.convert("RGB")) for image in examples["image"]]
         else:
             examples["image"] = [
                 transform(Image.frombytes("RGB", (height, width), image))
@@ -405,9 +393,7 @@ def build_hf_dataloader(
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Run single-node batch iteration benchmarks."
-    )
+    parser = argparse.ArgumentParser(description="Run single-node batch iteration benchmarks.")
 
     parser.add_argument(
         "--data-root",
@@ -432,8 +418,7 @@ if __name__ == "__main__":
         default=None,
         type=str,
         help=(
-            "Directory path with MDS files. Directory structure should be "
-            '"<data_root>/*.mds"'
+            "Directory path with MDS files. Directory structure should be " '"<data_root>/*.mds"'
         ),
     )
     parser.add_argument(

--- a/ray_data_eval/image_training/image_loader_microbenchmark.py
+++ b/ray_data_eval/image_training/image_loader_microbenchmark.py
@@ -234,6 +234,15 @@ def decode_image_crop_and_flip(row):
 
 
 def _collate_fn_arr_pil_images_to_tensor(batch: np.ndarray) -> torch.Tensor:
+    """
+    Custom collate function that converts a batch of numpy arrays representing PIL images to a tensor batch.
+
+    Args:
+        batch (np.ndarray): Batch of numpy arrays representing PIL images.
+
+    Returns:
+        torch.Tensor: Tensor batch of images.
+    """
     batch = batch["image"]
 
     arrays = np.transpose(batch, axes=(0, 3, 1, 2))
@@ -558,7 +567,10 @@ if __name__ == "__main__":
 
         # ray.data, with transform.
         ray_dataset = ray.data.read_images(
-            args.data_root, mode="RGB", transform=get_transform(False)
+            args.data_root,
+            mode="RGB",
+            # This `transform` argument works with the custom-built version of Ray available at https://github.com/franklsf95/ray
+            transform=get_transform(False),
         )
         for i in range(args.num_epochs):
             iterate(


### PR DESCRIPTION
Modify Ray+Transform pipeline to achieve higher tput:
- Remove `map`, where we originally pass in a function that transforms images;
- Add a custom `collate_fn` to `iter_torch_batches`, which converts `np.array` to `torch.Tensor` type in batches.

Thoughts
- The only thing that prevented the original `map_batches` pipeline from working is that the images were not resized to the same shape first, so we couldn't apply vectorization when converting to `torch.Tensor` type. If we can guarantee the images were resized to the same shape, then `map_batches` should be as fast as the currently proposed implementation. It does require breaking the composed `torchvision.transforms` functions into separate pieces, though (i.e. resize goes into the ray `read_images` API, and the rest of the transformations remain in place).

Note that we are using a custom-built Ray as documented in https://github.com/franklsf95/ray/pull/1.