### PR TITLE
Do not fail on corrupted video files

### DIFF
--- a/ray_data_eval/image_training/e2e_training/ray_data_download_from_s3.py
+++ b/ray_data_eval/image_training/e2e_training/ray_data_download_from_s3.py
@@ -1,0 +1,73 @@
+import boto3
+from boto3.s3.transfer import TransferConfig
+import os
+import time
+
+import ray
+
+# Download settings
+# Replace `s3_downloaded_images` with intended storage path.
+DEST_DIR = os.path.join(
+    os.getenv("HOME"),
+    "s3_downloaded_images",
+)
+BUCKET_NAME = "ray-data-eval-us-west-2"
+PREFIX = "imagenet/ILSVRC/Data/CLS-LOC"
+
+# Ray + S3 client settings
+RAY_NUM_CPU = 512
+S3_CLIENT_MAX_CONCURRENCY = 8192
+NUM_PARTITIONS = 10000
+
+
+def get_file_list(bucket=BUCKET_NAME):
+    s3 = boto3.client("s3", region_name="us-west-2")
+    paginator = s3.get_paginator(
+        "list_objects_v2"
+    )  # paginator abstracts the logic of handling continuation tokens
+
+    files = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=PREFIX):
+        if "Contents" in page:
+            for file in page["Contents"]:
+                files.append(f"s3://{bucket}/{file['Key']}")
+
+    return files
+
+
+@ray.remote
+def download(file_list):
+    s3 = boto3.client("s3", region_name="us-west-2")
+    transfer_config = TransferConfig(max_concurrency=S3_CLIENT_MAX_CONCURRENCY)
+
+    for uri in file_list:
+        bucket, key = uri.replace("s3://", "").split("/", 1)
+        local_path = os.path.join(DEST_DIR, key)
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        s3.download_file(bucket, key, local_path, Config=transfer_config)
+
+
+start = time.time()
+file_list = get_file_list()
+end = time.time()
+print("get_file_list wall time:", end - start)  # For Imagenet, this takes around 320s.
+
+# with open("temp.txt", "w") as f:
+#     f.write(repr(file_list))
+
+# with open("temp.txt", "r") as f:
+#     file_list = eval(f.read())
+
+start = time.time()
+num_partitions = NUM_PARTITIONS
+chunk_size = len(file_list) // num_partitions + (len(file_list) % num_partitions > 0)
+partitions = [file_list[i : i + chunk_size] for i in range(0, len(file_list), chunk_size)]
+
+print("num items:", len(file_list))
+print("num partitions:", num_partitions)
+print("chunk size:", chunk_size)
+
+ray.init(num_cpus=RAY_NUM_CPU)
+results = ray.get([download.remote(partition) for partition in partitions])
+end = time.time()
+print("download wall time:", end - start)


### PR DESCRIPTION
Occasionally, there are corrupted video files in the kinetics dataset. This will cause the entire training to stop in our current implementation, with the following error message displayed:
```
ray.exceptions.RayTaskError(UserCodeException): ray::ReadBinary->Map(preprocess_video)() (pid=54638, ip=10.0.34.58)
  File "/home/ubuntu/ray-data-eval/ray_data_eval/video_inference/ray_data_pipeline.py", line 94, in preprocess_video
    io.BytesIO(video_bytes),
  File "/home/ubuntu/miniconda3/envs/ray-gpu/lib/python3.10/site-packages/decord/video_reader.py", line 51, in __init__
    self._handle = _CAPI_VideoReaderGetVideoReader(
  File "/home/ubuntu/miniconda3/envs/ray-gpu/lib/python3.10/site-packages/decord/_ffi/_ctypes/function.py", line 173, in __call__
    check_call(_LIB.DECORDFuncCall(
  File "/home/ubuntu/miniconda3/envs/ray-gpu/lib/python3.10/site-packages/decord/_ffi/base.py", line 78, in check_call
    raise DECORDError(err_str)
decord._ffi.base.DECORDError: [08:14:23] /github/workspace/src/video/video_reader.cc:151: Check failed: st_nb >= 0 (-1381258232 vs. 0) ERROR cannot find video stream with wanted index: -1

```

The proposed fix is to store one `last_good_row` and use it as a stand-in whenever our `DataBatch` contains corrupted data. This should cause minimal disruption to throughput because only one video batch is copied and checking whether `is None` is fast.