### PR TITLE
Finish solver visualizer

### DIFF
--- a/ray_data_eval/libsolver/Cargo.lock
+++ b/ray_data_eval/libsolver/Cargo.lock
@@ -140,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +161,7 @@ dependencies = [
  "log",
  "pyo3",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -334,6 +341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +370,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/ray_data_eval/libsolver/Cargo.toml
+++ b/ray_data_eval/libsolver/Cargo.toml
@@ -18,6 +18,7 @@ itertools = "0.12.1"
 log = "0.4.20"
 pyo3 = { version = "0.19", features = ["extension-module"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [profile.release]
 opt-level = 3

--- a/ray_data_eval/libsolver/src/solver/environment.rs
+++ b/ray_data_eval/libsolver/src/solver/environment.rs
@@ -27,7 +27,7 @@ pub struct Buffer {
     consumable_timeline: Vec<usize>,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 struct TraceEvent {
     cat: String,
     name: String,
@@ -37,7 +37,7 @@ struct TraceEvent {
     dur: u64,
     ph: String,
     cname: String,
-    args: Option<std::collections::HashMap<String, String>>,
+    args: Option<HashMap<String, String>>,
 }
 
 impl PartialEq for Buffer {


### PR DESCRIPTION
Added `chrome://tracing` support for libsolver solutions. I defined a color map to convert task names (`P`, `C`, `I`, `T`) to colors, similar to what we did in #56. If we ever need more colors, e.g. for a multi-stage setup, we can easily extend the existing color map. I checked the results on training and test problems. Let me know if this works!

### Training Problem
```
[2024-07-16T11:30:56.729Z INFO  main::solver::environment] "P  P  C  C  C  C  P  C  C     "
[2024-07-16T11:30:56.729Z INFO  main::solver::environment] "P  C  C  P  C  C  P  C  C     "
[2024-07-16T11:30:56.729Z INFO  main::solver::environment] "P  C  C  P  C  C              "
[2024-07-16T11:30:56.729Z INFO  main::solver::environment] "         T        T  T     T  "
```
<img width="811" alt="image" src="https://github.com/user-attachments/assets/5c35621b-02ed-4051-b4e9-13f9e5216eb8">


### Test Problem
```
[2024-07-16T11:32:15.707Z INFO  main::solver::environment] "P  P  P  P  P  P  C  C  C  C  "
[2024-07-16T11:32:15.707Z INFO  main::solver::environment] "P  C  C  C  C  C  C  P  C  C  "
[2024-07-16T11:32:15.707Z INFO  main::solver::environment] "P  C  C  C  C  C  C  P  C  C  "
```
<img width="805" alt="image" src="https://github.com/user-attachments/assets/91e40ead-e1b8-460f-b0b6-6285020ada25">
